### PR TITLE
Removal of master and slave language

### DIFF
--- a/legoo.py
+++ b/legoo.py
@@ -37,7 +37,7 @@ hive_path='/usr/lib/hive/lib/py/'
 if hive_path not in sys.path:
       sys.path.insert(0, hive_path)
 
-trulia_mysql_host = ['bidbs', 'bidbm', 'bedb1', 'maildb-slave', 'db30', 'rodb-dash', 'db9', 'crad103']
+trulia_mysql_host = ['bidbs', 'bidbm', 'bedb1', 'maildb-subordinate', 'db30', 'rodb-dash', 'db9', 'crad103']
 
 def count_lines(**kwargs):
   """return line count for input file


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.